### PR TITLE
config.toml: update Google Analytics ID for GA4 migration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,9 @@
-base_url = "//docs.worldwidetelescope.org/lcapi-guide/1/"
+base_url = "https://docs.worldwidetelescope.org/lcapi-guide/1/"
 title = "WWT Layer Control API Guide"
 description = "Controlling the WWT Windows application with the LCAPI."
 theme = "wwtguide"
 highlight_code = true
 
 [extra]
-github_base = "//github.com/WorldWideTelescope/worldwide-telescope-lcapi-guide"
-google_analytics_id = "UA-107473046-3"
+github_base = "https://github.com/WorldWideTelescope/worldwide-telescope-lcapi-guide"
+google_analytics_id = "G-D1J49XX0CV"

--- a/content/lcapicommands.md
+++ b/content/lcapicommands.md
@@ -147,9 +147,6 @@ Might receive the following response:
 The **getprops** command is used to retrieve all the properties for a
 specified layer.
 
-Refer to the [table of properties](#table-of-properties) listed for the
-[**getprop**](#getprop) command.
-
 | Required Parameters | Description |
 | :-- | :-- |
 | *id* | Specifies the id number of the layer. |


### PR DESCRIPTION
More Google Analytics 4 migration. For a comprehensive set of all PR's, see:

https://github.com/WorldWideTelescope/wwt-website/pull/305